### PR TITLE
feat: add live mews end-to-end harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ dist
 node_modules
 .DS_Store
 coverage
+.artifacts
 *.log

--- a/README.md
+++ b/README.md
@@ -20,5 +20,12 @@ Main commands:
 - `mews status`
 - `mews watch`
 - `mews poll`
+- `pnpm e2e:live`
 
 Runtime data lives under `~/.mews/`.
+
+Live end-to-end:
+
+- `pnpm e2e:live` builds the CLI, starts the daemon in `--dry-run` mode, creates a temporary probe issue in `bingran-you/mews`, uses a secondary GitHub actor to mention the primary user, and verifies `/inbox`, `/tasks`, and the browser dashboard.
+- Set either `MEWS_E2E_SECONDARY_USER` or `MEWS_E2E_SECONDARY_TOKEN`.
+- Run `pnpm e2e:live:install-browser` once before the first browser-backed run.

--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -64,6 +64,7 @@
   .badge.done { background: color-mix(in srgb, var(--done) 15%, transparent); color: var(--done); }
   .label-chip { display: inline-block; font-size: 10px; padding: 0 6px; border-radius: 6px; background: var(--border); color: var(--muted); margin-right: 4px; }
   .empty { padding: 40px 20px; text-align: center; color: var(--muted); }
+  .section-title { margin: 22px 0 8px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
 </style>
 </head>
 <body>
@@ -89,9 +90,18 @@
     <tbody id="rows"></tbody>
   </table>
   <div class="empty" id="empty" hidden>No notifications.</div>
+
+  <div class="section-title">tasks</div>
+  <table>
+    <thead><tr>
+      <th>status</th><th>kind</th><th>repo</th><th>title</th><th>summary</th><th class="updated">started</th><th class="updated">finished</th>
+    </tr></thead>
+    <tbody id="task-rows"></tbody>
+  </table>
+  <div class="empty" id="tasks-empty" hidden>No task activity yet.</div>
 </main>
 <script>
-  const state = { inbox: null, filter: "all", query: "" };
+  const state = { inbox: null, tasks: [], filter: "all", query: "" };
 
   function format(ts) {
     if (!ts) return "—";
@@ -146,6 +156,22 @@
     document.getElementById("empty").hidden = rows.length > 0;
   }
 
+  function renderTasks() {
+    const rows = (state.tasks || [])
+      .map(task => `<tr>
+        <td><span class="badge ${(task.status || "done") === "simulated" ? "wip" : escape(task.status || "done")}">${escape(task.status || "done")}</span></td>
+        <td>${escape(task.kind)}</td>
+        <td class="repo">${escape(task.repo)}</td>
+        <td>${escape(task.title)}</td>
+        <td>${escape(task.summary)}</td>
+        <td class="updated" title="${escape(task.started_at)}">${format(task.started_at)}</td>
+        <td class="updated" title="${escape(task.finished_at)}">${format(task.finished_at)}</td>
+      </tr>`)
+      .join("");
+    document.getElementById("task-rows").innerHTML = rows;
+    document.getElementById("tasks-empty").hidden = rows.length > 0;
+  }
+
   async function fetchInbox() {
     try {
       const res = await fetch("/inbox", { cache: "no-store" });
@@ -158,6 +184,19 @@
     }
   }
 
+  async function fetchTasks() {
+    try {
+      const res = await fetch("/tasks", { cache: "no-store" });
+      if (res.ok) {
+        const payload = await res.json();
+        state.tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
+        renderTasks();
+      }
+    } catch (error) {
+      console.warn("tasks fetch failed", error);
+    }
+  }
+
   function connectSse() {
     const ev = new EventSource("/events");
     const pill = document.getElementById("sse-status");
@@ -165,8 +204,14 @@
       pill.textContent = "live";
       pill.classList.add("live");
     });
-    ev.addEventListener("inbox", () => fetchInbox());
-    ev.addEventListener("activity", () => fetchInbox());
+    ev.addEventListener("inbox", () => {
+      fetchInbox();
+      fetchTasks();
+    });
+    ev.addEventListener("activity", () => {
+      fetchInbox();
+      fetchTasks();
+    });
     ev.onerror = () => {
       pill.textContent = "offline — retrying";
       pill.classList.remove("live");
@@ -187,6 +232,7 @@
   });
 
   fetchInbox();
+  fetchTasks();
   connectSse();
 </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "e2e:live": "pnpm build && node ./scripts/live-e2e.mjs",
+    "e2e:live:install-browser": "playwright install chromium",
     "prepack": "pnpm build",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -40,6 +42,7 @@
     "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.2.14",
     "ink-testing-library": "^4.0.0",
+    "playwright": "^1.53.2",
     "tsdown": "^0.12.0",
     "typescript": "^5.8.0",
     "vitest": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       ink-testing-library:
         specifier: ^4.0.0
         version: 4.0.0(@types/react@19.2.14)
+      playwright:
+        specifier: ^1.53.2
+        version: 1.59.1
       tsdown:
         specifier: ^0.12.0
         version: 0.12.9(typescript@5.9.3)
@@ -675,6 +678,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -779,6 +787,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -1534,6 +1552,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1624,6 +1645,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.12:
     dependencies:

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { chromium } from "playwright";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const timestamp = Date.now();
+const repo = process.env.MEWS_E2E_REPO ?? "bingran-you/mews";
+const actorUser = process.env.MEWS_E2E_SECONDARY_USER;
+const actorToken = process.env.MEWS_E2E_SECONDARY_TOKEN;
+const port = Number(process.env.MEWS_E2E_HTTP_PORT ?? "8787");
+const pollIntervalSecs = Number(process.env.MEWS_E2E_POLL_INTERVAL_SECS ?? "5");
+const artifactsRoot = resolve(
+  repoRoot,
+  ".artifacts",
+  "live-e2e",
+  String(timestamp),
+);
+const stateRoot = join(artifactsRoot, "state");
+const runnerHome = join(stateRoot, "runner");
+const dashboardScreenshot = join(artifactsRoot, "dashboard.png");
+const daemonLog = join(artifactsRoot, "daemon.log");
+const traceFile = join(artifactsRoot, "trace.log");
+
+mkdirSync(artifactsRoot, { recursive: true });
+mkdirSync(stateRoot, { recursive: true });
+
+let issueNumber = null;
+let daemon = null;
+let primaryUser = null;
+let switchedAccount = false;
+
+function log(line) {
+  process.stdout.write(`${line}\n`);
+  writeFileSync(traceFile, `${line}\n`, { flag: "a" });
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function execGh(args, options = {}) {
+  const env = { ...process.env, ...(options.env ?? {}) };
+  return execFileSync("gh", args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+async function sleep(ms) {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+async function waitFor(check, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 90_000;
+  const intervalMs = options.intervalMs ?? 1_500;
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const value = await check();
+    if (value) return value;
+    await sleep(intervalMs);
+  }
+  throw new Error(options.label ?? "Timed out");
+}
+
+async function fetchJson(pathname) {
+  const response = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`GET ${pathname} failed with ${response.status}`);
+  }
+  return response.json();
+}
+
+function appendDaemonLog(chunk) {
+  writeFileSync(daemonLog, chunk, { flag: "a" });
+}
+
+function ensureSecondaryActor() {
+  if (!actorToken && !actorUser) {
+    fail(
+      "Set MEWS_E2E_SECONDARY_USER or MEWS_E2E_SECONDARY_TOKEN so a second actor can generate a real mention notification.",
+    );
+  }
+}
+
+function detectPrimaryUser() {
+  primaryUser = execGh(["api", "/user", "-q", ".login"]);
+  return primaryUser;
+}
+
+function switchAccount(user) {
+  execGh(["auth", "switch", "--hostname", "github.com", "--user", user]);
+}
+
+function createProbeIssue(title) {
+  const body = [
+    "Temporary issue created by the live mews end-to-end harness.",
+    "",
+    "The harness will close it automatically after verification.",
+  ].join("\n");
+  const created = JSON.parse(
+    execGh([
+      "api",
+      `/repos/${repo}/issues`,
+      "-f",
+      `title=${title}`,
+      "-f",
+      `body=${body}`,
+      "-F",
+      `assignees[]=${primaryUser}`,
+    ]),
+  );
+  return created.number;
+}
+
+function postSecondaryMention(issue, mentionBody) {
+  if (actorToken) {
+    execGh(
+      ["issue", "comment", String(issue), "--repo", repo, "--body", mentionBody],
+      { env: { GH_TOKEN: actorToken } },
+    );
+    return;
+  }
+
+  switchAccount(actorUser);
+  switchedAccount = true;
+  try {
+    execGh([
+      "issue",
+      "comment",
+      String(issue),
+      "--repo",
+      repo,
+      "--body",
+      mentionBody,
+    ]);
+  } finally {
+    switchAccount(primaryUser);
+    switchedAccount = false;
+  }
+}
+
+function startDaemon() {
+  const child = spawn(
+    process.execPath,
+    [
+      "dist/cli.js",
+      "run",
+      "--allow-repo",
+      repo,
+      "--http-port",
+      String(port),
+      "--poll-interval-secs",
+      String(pollIntervalSecs),
+      "--dry-run",
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        MEWS_DIR: stateRoot,
+        MEWS_HOME: runnerHome,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.stdout.on("data", (chunk) => appendDaemonLog(chunk));
+  child.stderr.on("data", (chunk) => appendDaemonLog(chunk));
+  daemon = child;
+  return child;
+}
+
+async function stopDaemon() {
+  if (!daemon) return;
+  if (daemon.exitCode !== null) return;
+  daemon.kill("SIGTERM");
+  await new Promise((resolvePromise) => daemon.once("exit", resolvePromise));
+}
+
+async function closeProbeIssue() {
+  if (issueNumber === null) return;
+  try {
+    execGh([
+      "issue",
+      "close",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--comment",
+      "Closing temporary mews live e2e probe.",
+    ]);
+  } catch (error) {
+    log(`WARN: failed to close probe issue #${issueNumber}: ${String(error)}`);
+  }
+}
+
+async function verifyDashboard(title) {
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch (error) {
+    fail(
+      `Could not launch Chromium. Run \`pnpm e2e:live:install-browser\` first. ${String(error)}`,
+    );
+  }
+
+  try {
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${port}/dashboard`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.locator("#rows tr", { hasText: title }).waitFor({
+      timeout: 90_000,
+    });
+    const taskRow = page.locator("#task-rows tr", { hasText: title });
+    await taskRow.waitFor({
+      timeout: 90_000,
+    });
+    await taskRow.getByText("simulated").waitFor({ timeout: 90_000 });
+    await page.screenshot({ path: dashboardScreenshot, fullPage: true });
+  } finally {
+    await browser.close();
+  }
+}
+
+async function main() {
+  ensureSecondaryActor();
+  detectPrimaryUser();
+  log(`Primary GitHub user: ${primaryUser}`);
+  log(`Artifacts: ${artifactsRoot}`);
+
+  if (!existsSync(join(repoRoot, "dist", "cli.js"))) {
+    fail("dist/cli.js is missing. Run `pnpm build` first.");
+  }
+
+  const title = `[mews live e2e ${timestamp}]`;
+  const mentionBody = `@${primaryUser} live mews end-to-end probe from a secondary actor.`;
+
+  startDaemon();
+  await waitFor(
+    async () => {
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+        return response.ok;
+      } catch {
+        return false;
+      }
+    },
+    { label: "Daemon health check did not come up" },
+  );
+
+  issueNumber = createProbeIssue(title);
+  log(`Created probe issue #${issueNumber}`);
+  postSecondaryMention(issueNumber, mentionBody);
+  log("Posted secondary mention comment");
+
+  const inboxPayload = await waitFor(
+    async () => {
+      try {
+        const payload = await fetchJson("/inbox");
+        return payload.notifications?.some((entry) => entry.title === title)
+          ? payload
+          : null;
+      } catch {
+        return null;
+      }
+    },
+    { label: "Probe issue never appeared in /inbox" },
+  );
+  writeFileSync(
+    join(artifactsRoot, "inbox.json"),
+    JSON.stringify(inboxPayload, null, 2),
+  );
+
+  const tasksPayload = await waitFor(
+    async () => {
+      try {
+        const payload = await fetchJson("/tasks");
+        return payload.tasks?.some((task) => task.title === title)
+          ? payload
+          : null;
+      } catch {
+        return null;
+      }
+    },
+    { label: "Probe task never appeared in /tasks" },
+  );
+  writeFileSync(
+    join(artifactsRoot, "tasks.json"),
+    JSON.stringify(tasksPayload, null, 2),
+  );
+
+  const activityPayload = await fetchJson("/activity");
+  writeFileSync(
+    join(artifactsRoot, "activity.json"),
+    JSON.stringify(activityPayload, null, 2),
+  );
+
+  await verifyDashboard(title);
+
+  log(`Dashboard screenshot: ${dashboardScreenshot}`);
+  log("Live mews end-to-end verification passed.");
+}
+
+try {
+  await main();
+} catch (error) {
+  log(`ERROR: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  process.exitCode = 1;
+} finally {
+  if (switchedAccount && primaryUser) {
+    try {
+      switchAccount(primaryUser);
+    } catch {
+      // best effort
+    }
+  }
+  await closeProbeIssue();
+  await stopDaemon();
+}

--- a/src/mews/README.md
+++ b/src/mews/README.md
@@ -1,9 +1,8 @@
 # `mews`
 
-Local daemon that takes over your `gh` login and turns explicit GitHub review
-requests and direct mentions into a triaged, optionally auto-handled inbox.
-Drives a Claude Code statusline, an SSE dashboard, and scheduled background
-work.
+Local daemon that monitors GitHub notifications for an allow-listed set of
+repositories, keeps a triaged inbox, exposes a browser dashboard, and can
+dispatch local coding agents in the background.
 
 ## What's In This Directory
 
@@ -32,7 +31,7 @@ mews/
 | `mews status` | Print current daemon/runtime status |
 | `mews doctor` | Diagnose daemon / gh login / runtime health |
 | `mews watch` | Interactive TUI inbox (Ink) |
-| `mews poll` | One-shot inbox poll without requiring the daemon |
+| `mews poll [--allow-repo owner/repo]` | One-shot inbox poll without requiring the daemon |
 
 ### Advanced / internal
 

--- a/src/mews/cli.ts
+++ b/src/mews/cli.ts
@@ -33,8 +33,7 @@ Primary commands (start here):
   status                Print daemon lock + runtime/status.env
   doctor                Diagnose the local install
   watch                 Live TUI: status board + activity feed
-  poll                  Poll explicit GitHub review requests and mentions
-                        once (no daemon required)
+  poll                  Poll GitHub notifications once (no daemon required)
 
 Advanced commands (for agents or debugging):
   run, daemon           Run the broker loop in the foreground.
@@ -72,6 +71,7 @@ const MEWS_INLINE_HELP: Partial<Record<string, string>> = {
     --task-timeout-secs <n>      Per-task timeout
     --max-parallel <n>           Max concurrent agent tasks
     --search-limit <n>           Max search-derived candidates per cycle
+    --dry-run                    Schedule tasks without invoking agents
 `,
   daemon: `usage: mews daemon [options]
 
@@ -84,6 +84,7 @@ const MEWS_INLINE_HELP: Partial<Record<string, string>> = {
 
   Options:
     --allow-repo <csv>           Required: restrict work to owner/repo or owner/* patterns
+    --dry-run                    Schedule tasks without invoking agents
 `,
   watch: `usage: mews watch
 

--- a/src/mews/engine/commands/poll.ts
+++ b/src/mews/engine/commands/poll.ts
@@ -40,8 +40,13 @@ import { classifyMewsStatus } from "../runtime/classifier.js";
 import { loadMewsConfig } from "../runtime/config.js";
 import { GhClient, GhExecError } from "../runtime/gh.js";
 import { resolveMewsPaths } from "../runtime/paths.js";
+import { RepoFilter } from "../runtime/repo-filter.js";
 import { updateInbox } from "../runtime/store.js";
 import { shouldTrackReason } from "../runtime/task-kind.js";
+import {
+  parseAllowRepoArg,
+  requireExplicitRepoFilter,
+} from "../runtime/allow-repo.js";
 import {
   type GhState,
   type Inbox,
@@ -75,7 +80,7 @@ function formatUtcIso(date: Date): string {
   return `${date.toISOString().slice(0, 19)}Z`;
 }
 
-/** Raw GitHub notification as returned by `/notifications?participating=true`. */
+/** Raw GitHub notification as returned by `/notifications`. */
 interface RawNotification {
   id?: string;
   reason?: string;
@@ -139,6 +144,7 @@ function htmlUrlFor(
 export function parseNotifications(
   rawJsonPages: readonly string[],
   host: string,
+  repoFilter: RepoFilter = RepoFilter.empty(),
 ): InboxEntry[] {
   const entries: InboxEntry[] = [];
   const seenIds = new Set<string>();
@@ -160,6 +166,7 @@ export function parseNotifications(
       if (subjectType === "CheckSuite" || subjectType === "Commit") continue;
       const repo = item.repository?.full_name ?? "";
       if (!repo) continue;
+      if (!repoFilter.matchesRepo(repo)) continue;
       const reason = item.reason ?? "";
       if (!shouldTrackReason(reason)) continue;
       const title = item.subject?.title ?? "";
@@ -530,6 +537,12 @@ export async function runPoll(
   const io = deps.io ?? DEFAULT_IO;
   const config = loadMewsConfig();
   const paths = deps.paths ?? resolveMewsPaths();
+  const repoFilter = (() => {
+    const allowRepo = parseAllowRepoArg(argv);
+    return allowRepo?.trim()
+      ? requireExplicitRepoFilter(allowRepo)
+      : RepoFilter.empty();
+  })();
   const gh = deps.gh ?? new GhClient();
   const now = deps.now ?? (() => new Date());
   const append = deps.appendActivity ?? appendActivityEvent;
@@ -554,9 +567,7 @@ export async function runPoll(
   try {
     const stdout = gh.runChecked("fetch notifications", [
       "api",
-      // See #251: `all=true` bypassed GitHub's spam filter. `participating=true`
-      // restricts to direct-participation notifications.
-      "/notifications?participating=true",
+      "/notifications?all=true&per_page=100",
       "--paginate",
       "-H",
       "X-GitHub-Api-Version: 2022-11-28",
@@ -570,7 +581,7 @@ export async function runPoll(
     throw err;
   }
 
-  const entries = parseNotifications(rawPages, config.host);
+  const entries = parseNotifications(rawPages, config.host, repoFilter);
   sortEntries(entries);
 
   const enrichmentWarning = enrichWithLabels(entries, gh, config.host);

--- a/src/mews/engine/daemon/gh-client.ts
+++ b/src/mews/engine/daemon/gh-client.ts
@@ -85,10 +85,7 @@ export class GhClient {
       "read recent notifications",
       [
         "api",
-        // See #251: `all=true&participating=false` bypassed GitHub's server-side
-        // spam filter and let mews act on mention-then-delete notifications.
-        // `participating=true` restricts to direct-participation notifications.
-        "/notifications?participating=true&per_page=100",
+        "/notifications?all=true&per_page=100",
         "--paginate",
         "-H",
         "X-GitHub-Api-Version: 2022-11-28",

--- a/src/mews/engine/daemon/http.ts
+++ b/src/mews/engine/daemon/http.ts
@@ -42,6 +42,7 @@ import {
   runSseStream,
   type SseBus,
 } from "./sse.js";
+import type { DashboardTask } from "./thread-store.js";
 
 /**
  * Routes matched against the path component after the query is stripped.
@@ -52,6 +53,7 @@ export type Route =
   | "dashboard"
   | "healthz"
   | "inbox"
+  | "tasks"
   | "activity"
   | "events"
   | "not-found";
@@ -69,6 +71,8 @@ export function parseRoute(method: string, url: string | undefined): Route {
       return "healthz";
     case "/inbox":
       return "inbox";
+    case "/tasks":
+      return "tasks";
     case "/activity":
       return "activity";
     case "/events":
@@ -215,6 +219,19 @@ async function writeInboxJsonFile(
   res.end(contents);
 }
 
+function writeJson(
+  res: ServerResponse,
+  body: string,
+): void {
+  res.writeHead(200, "OK", {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(body, "utf-8"),
+    "Cache-Control": "no-store",
+    Connection: "close",
+  });
+  res.end(body);
+}
+
 function writeActivityTail(
   res: ServerResponse,
   activityPath: string,
@@ -264,6 +281,8 @@ export interface StartHttpServerOptions {
   inboxPath: string;
   /** Path to `~/.mews/activity.log`. */
   activityLogPath: string;
+  /** Task metadata snapshot used by the dashboard task pane. */
+  tasksProvider?: () => DashboardTask[];
   /** Shutdown signal. Server closes when this aborts. */
   signal: AbortSignal;
   /**
@@ -343,6 +362,14 @@ export async function startHttpServer(
               );
               if (!res.headersSent) writePlain(res, 404, "inbox.json not found\n");
             });
+            return;
+          case "tasks":
+            writeJson(
+              res,
+              JSON.stringify({
+                tasks: (options.tasksProvider ?? (() => []))(),
+              }),
+            );
             return;
           case "activity":
             writeActivityTail(res, options.activityLogPath, ACTIVITY_TAIL_LIMIT);

--- a/src/mews/engine/daemon/poller.ts
+++ b/src/mews/engine/daemon/poller.ts
@@ -40,6 +40,7 @@ import { existsSync, mkdirSync } from "node:fs";
 
 import { appendActivityEvent } from "../runtime/activity-log.js";
 import { GhClient, GhExecError } from "../runtime/gh.js";
+import { RepoFilter } from "../runtime/repo-filter.js";
 import type { MewsPaths } from "../runtime/paths.js";
 import { updateInbox } from "../runtime/store.js";
 import {
@@ -73,6 +74,8 @@ export interface PollerOptions {
   gh?: GhClient;
   /** Filesystem layout. Production code passes `resolveMewsPaths()`. */
   paths: MewsPaths;
+  /** Restrict inbox visibility to the same allow-list used by dispatch. */
+  repoFilter?: RepoFilter;
   /** Abort signal for cooperative shutdown (wired from SIGTERM handler). */
   signal?: AbortSignal;
   /** `Date.now`-style clock override for tests. */
@@ -102,6 +105,7 @@ interface PollOnceDeps {
   paths: MewsPaths;
   host: string;
   now: () => number;
+  repoFilter?: RepoFilter;
 }
 
 /** Seconds-precision ISO-8601 UTC, matching `date -u +%Y-%m-%dT%H:%M:%SZ`. */
@@ -174,14 +178,7 @@ export async function pollOnce(deps: PollOnceDeps): Promise<PollOutcome> {
   try {
     const stdout = gh.runChecked("fetch notifications", [
       "api",
-      // `participating=true` restricts to direct-participation notifications
-      // and respects GitHub's server-side spam filter. `parseNotifications`
-      // further narrows those results to explicit mentions and review
-      // requests so mews does not act on generic author/assignee/comment
-      // traffic. `?all=true` was previously used here but bypassed the
-      // filter, causing mews to act on mention-then-delete spam surfaced
-      // to no one in the UI (#251).
-      "/notifications?participating=true",
+      "/notifications?all=true&per_page=100",
       "--paginate",
       "-H",
       "X-GitHub-Api-Version: 2022-11-28",
@@ -204,7 +201,7 @@ export async function pollOnce(deps: PollOnceDeps): Promise<PollOutcome> {
     throw err;
   }
 
-  const entries = parseNotifications(rawPages, host);
+  const entries = parseNotifications(rawPages, host, deps.repoFilter ?? RepoFilter.empty());
   sortEntries(entries);
 
   const enrichmentWarning = enrichWithLabels(entries, gh, host);
@@ -285,6 +282,7 @@ export async function runPoller(options: PollerOptions): Promise<void> {
         paths: options.paths,
         host: options.host,
         now,
+        repoFilter: options.repoFilter ?? RepoFilter.empty(),
       });
     } catch (err) {
       // Local/setup error (not a gh-side failure). Log and retry after

--- a/src/mews/engine/daemon/runner-skeleton.ts
+++ b/src/mews/engine/daemon/runner-skeleton.ts
@@ -72,6 +72,8 @@ export interface DaemonCliOverrides {
    * Patterns are `owner/repo` or `owner/*`.
    */
   allowRepo?: string;
+  /** When true, schedule tasks without invoking agents. */
+  dryRun?: boolean;
 }
 
 export interface DaemonRunOptions {
@@ -113,6 +115,7 @@ const DEFAULT_LOGGER: PollerLogger = {
  *   --search-limit <n>
  *   --allow-repo <csv>            (owner/repo,owner/* — required for daemon
  *                                  startup; scopes the daemon to listed repos)
+ *   --dry-run                     schedule tasks without invoking agents
  *
  * Both `--flag value` and `--flag=value` forms are accepted for
  * `--allow-repo`, `--max-parallel`, and `--search-limit`.
@@ -153,6 +156,9 @@ export function parseDaemonArgs(argv: readonly string[]): DaemonCliOverrides {
         }
         break;
       }
+      case "--dry-run":
+        overrides.dryRun = true;
+        break;
       case "--poll-interval-secs":
       case "--poll-interval-sec": {
         const value = next();
@@ -393,7 +399,7 @@ export async function runDaemon(
   runtimeTicker.unref?.();
 
   logger.info(
-    `mews daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort} max-parallel=${config.maxParallel} search-limit=${config.searchLimit} allow-repo=${repoFilter.isEmpty() ? "all" : repoFilter.displayPatterns()}`,
+    `mews daemon: poll-interval=${config.pollIntervalSec}s host=${config.host} http-port=${config.httpPort} max-parallel=${config.maxParallel} search-limit=${config.searchLimit} allow-repo=${repoFilter.isEmpty() ? "all" : repoFilter.displayPatterns()} dry-run=${cliOverrides.dryRun ? "true" : "false"}`,
   );
 
   // Phase 3c: shared in-process bus drives SSE + broker task events.
@@ -468,6 +474,7 @@ export async function runDaemon(
           "This reply was drafted by mews, an autonomous agent running on behalf of the account owner.",
         maxParallel: config.maxParallel,
         taskTimeoutMs: config.taskTimeoutSec * 1_000,
+        dryRun: cliOverrides.dryRun === true,
         logger,
         onCompletion: (record) => scheduler.handleCompletion(record),
       });
@@ -530,13 +537,14 @@ export async function runDaemon(
   let httpServer: RunningHttpServer | null = null;
   if (!controller.signal.aborted) {
     try {
-      httpServer = await startHttpServer({
-        httpPort: config.httpPort,
-        inboxPath: paths.inbox,
-        activityLogPath: paths.activityLog,
-        bus: toSseBus(bus),
-        signal: controller.signal,
-        logger,
+        httpServer = await startHttpServer({
+          httpPort: config.httpPort,
+          inboxPath: paths.inbox,
+          activityLogPath: paths.activityLog,
+          tasksProvider: () => runtimeStore.listDashboardTasks(),
+          bus: toSseBus(bus),
+          signal: controller.signal,
+          logger,
       });
     } catch (err) {
       logger.error(
@@ -558,7 +566,7 @@ export async function runDaemon(
       // One-shot: run a single poll cycle, then wait for the
       // dispatcher to drain. Also run one candidate-search cycle so
       // assigned/review-requested work is not lost before shutdown.
-      await runPollerOnce(config, paths, controller.signal, logger);
+      await runPollerOnce(config, paths, repoFilter, controller.signal, logger);
       if (candidateRuntime) {
         const outcome = await runCandidateCycle(
           {
@@ -579,6 +587,7 @@ export async function runDaemon(
         pollIntervalSec: config.pollIntervalSec,
         host: config.host,
         paths,
+        repoFilter,
         signal: controller.signal,
         logger,
       });
@@ -713,6 +722,7 @@ function logCandidateOutcome(
 async function runPollerOnce(
   config: DaemonConfig,
   paths: MewsPaths,
+  repoFilter: RepoFilter,
   signal: AbortSignal,
   logger: PollerLogger,
 ): Promise<void> {
@@ -721,6 +731,7 @@ async function runPollerOnce(
     const outcome = await pollOnce({
       gh: new CoreGhClient(),
       paths,
+      repoFilter,
       host: config.host,
       now: Date.now,
     });

--- a/src/mews/engine/daemon/scheduler.ts
+++ b/src/mews/engine/daemon/scheduler.ts
@@ -139,6 +139,19 @@ export class Scheduler {
   handleCompletion(record: CompletionRecord): void {
     const now = this.nowSec();
     const meta = this.store.readTaskMetadata(record.taskId);
+    meta.set("task_id", record.taskId);
+    meta.set("repo", record.candidate.repo);
+    meta.set(
+      "workspace_repo",
+      record.candidate.workspaceRepo?.trim().length
+        ? record.candidate.workspaceRepo
+        : record.candidate.repo,
+    );
+    meta.set("thread_key", record.threadKey);
+    meta.set("title", encodeMultiline(record.candidate.title));
+    meta.set("kind", record.candidate.kind);
+    meta.set("updated_at", record.candidate.updatedAt);
+    if (!meta.has("started_at")) meta.set("started_at", String(now));
     meta.set("finished_at", String(now));
 
     let threadRecord = this.store.loadThreadRecord(record.threadKey);

--- a/src/mews/engine/daemon/thread-store.ts
+++ b/src/mews/engine/daemon/thread-store.ts
@@ -31,6 +31,7 @@ import {
 import { dirname, join } from "node:path";
 
 import {
+  decodeMultiline,
   parseKvLines,
   stableFileId,
 } from "../runtime/task-util.js";
@@ -43,6 +44,22 @@ import {
 
 export interface ThreadStoreOptions {
   runnerHome: string;
+}
+
+export interface DashboardTask {
+  task_id: string;
+  status: string;
+  repo: string;
+  workspace_repo: string;
+  thread_key: string;
+  title: string;
+  kind: string;
+  source: string;
+  updated_at: string;
+  started_at: string;
+  finished_at: string;
+  runner: string;
+  summary: string;
 }
 
 export class ThreadStore {
@@ -113,6 +130,31 @@ export class ThreadStore {
       out.push([name, this.readTaskMetadata(name)]);
     }
     return out;
+  }
+
+  listDashboardTasks(): DashboardTask[] {
+    return this.listTaskMetadata()
+      .map(([taskId, metadata]) => ({
+        task_id: metadata.get("task_id") ?? taskId,
+        status: metadata.get("status") ?? "",
+        repo: metadata.get("repo") ?? "",
+        workspace_repo: metadata.get("workspace_repo") ?? "",
+        thread_key: metadata.get("thread_key") ?? "",
+        title: decodeMultiline(metadata.get("title") ?? ""),
+        kind: metadata.get("kind") ?? "",
+        source: metadata.get("source") ?? "",
+        updated_at: metadata.get("updated_at") ?? "",
+        started_at: metadata.get("started_at") ?? "",
+        finished_at: metadata.get("finished_at") ?? "",
+        runner: metadata.get("runner") ?? "",
+        summary: decodeMultiline(metadata.get("summary") ?? ""),
+      }))
+      .sort((a, b) => {
+        const left = a.started_at || a.updated_at || a.task_id;
+        const right = b.started_at || b.updated_at || b.task_id;
+        if (left === right) return 0;
+        return left < right ? 1 : -1;
+      });
   }
 
   writeRuntimeStatus(values: Record<string, string>): void {

--- a/tests/mews/mews-daemon-gh-client.test.ts
+++ b/tests/mews/mews-daemon-gh-client.test.ts
@@ -118,7 +118,7 @@ describe("GhClient.recentNotifications", () => {
     expect(tasks[0].kind).toBe("mention");
     // Assert the argv sent to gh contains the paginate + notifications endpoint.
     expect(ctl.calls[0].args).toContain("--paginate");
-    expect(ctl.calls[0].args).toContain("/notifications?participating=true&per_page=100");
+    expect(ctl.calls[0].args).toContain("/notifications?all=true&per_page=100");
   });
 
   it("drops lines that predate the lookback window", async () => {

--- a/tests/mews/mews-daemon-http.test.ts
+++ b/tests/mews/mews-daemon-http.test.ts
@@ -28,6 +28,7 @@ import {
   startHttpServer,
   tailAsJsonArray,
 } from "../../src/mews/engine/daemon/http.js";
+import type { DashboardTask } from "../../src/mews/engine/daemon/thread-store.js";
 import {
   encodeSseFrame,
   encodeSseEvent,
@@ -137,6 +138,7 @@ describe("parseRoute", () => {
     expect(parseRoute("GET", "/index.html")).toBe("dashboard");
     expect(parseRoute("GET", "/healthz")).toBe("healthz");
     expect(parseRoute("GET", "/inbox")).toBe("inbox");
+    expect(parseRoute("GET", "/tasks")).toBe("tasks");
     expect(parseRoute("GET", "/activity")).toBe("activity");
     expect(parseRoute("GET", "/events")).toBe("events");
     // query strings are stripped
@@ -242,14 +244,21 @@ describe("SSE framing — byte-level parity with Rust send_sse", () => {
 /* Integration tests — real bound server                               */
 /* ------------------------------------------------------------------ */
 
-async function startTestServer(ctx: Ctx, busOverride?: SseBus) {
+async function startTestServer(
+  ctx: Ctx,
+  options: {
+    busOverride?: SseBus;
+    tasksProvider?: () => DashboardTask[];
+  } = {},
+) {
   const controller = new AbortController();
   const server = await startHttpServer({
     httpPort: 0, // ephemeral port
     inboxPath: ctx.inbox,
     activityLogPath: ctx.activity,
     signal: controller.signal,
-    bus: busOverride,
+    bus: options.busOverride,
+    tasksProvider: options.tasksProvider,
     logger: SILENT_LOGGER,
     // speed up keep-alive cadence for the test that covers it
     sseKeepAliveMs: 50,
@@ -329,6 +338,40 @@ describe("startHttpServer — route contracts", () => {
     expect(res.body.toString("utf-8")).toBe("inbox.json not found\n");
   });
 
+  it("GET /tasks returns the current task snapshot", async () => {
+    ({ controller, server } = await startTestServer(ctx, {
+      tasksProvider: () => [
+        {
+          task_id: "task-1",
+          status: "simulated",
+          repo: "bingran-you/mews",
+          workspace_repo: "bingran-you/mews",
+          thread_key: "/repos/bingran-you/mews/issues/1",
+          title: "probe",
+          kind: "mention",
+          source: "notifications",
+          updated_at: "2026-04-28T23:00:00Z",
+          started_at: "2026-04-28T23:00:01Z",
+          finished_at: "2026-04-28T23:00:02Z",
+          runner: "",
+          summary: "dry-run scheduled task",
+        },
+      ],
+    }));
+    const res = await fetchRaw(server.port, "/tasks");
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
+    expect(JSON.parse(res.body.toString("utf-8"))).toEqual({
+      tasks: [
+        expect.objectContaining({
+          task_id: "task-1",
+          status: "simulated",
+          title: "probe",
+        }),
+      ],
+    });
+  });
+
   it("GET /activity returns [] when the file is absent (always 200)", async () => {
     ({ controller, server } = await startTestServer(ctx));
     const res = await fetchRaw(server.port, "/activity");
@@ -385,7 +428,7 @@ describe("startHttpServer — /events SSE stream", () => {
 
   it("emits 200 SSE headers + ready frame + bus events byte-for-byte", async () => {
     const manual = makeManualBus();
-    ({ controller, server } = await startTestServer(ctx, manual.bus));
+    ({ controller, server } = await startTestServer(ctx, { busOverride: manual.bus }));
 
     // Open the SSE connection manually so we can read the raw bytes
     // and compare against the Rust fixture frames.
@@ -459,7 +502,7 @@ describe("startHttpServer — /events SSE stream", () => {
 
   it("emits a keep-alive `: ping\\n\\n` comment when the bus is idle", async () => {
     const manual = makeManualBus();
-    ({ controller, server } = await startTestServer(ctx, manual.bus));
+    ({ controller, server } = await startTestServer(ctx, { busOverride: manual.bus }));
 
     let combined = "";
 

--- a/tests/mews/mews-daemon-poller.test.ts
+++ b/tests/mews/mews-daemon-poller.test.ts
@@ -182,13 +182,13 @@ describe("pollOnce parity with Rust fetcher", () => {
     expect(outcome.warnings).toEqual([]);
     expect(outcome.rateLimited).toBe(false);
 
-    // #251: must hit /notifications?participating=true (not ?all=true),
-    // which respects GitHub's server-side spam filter.
+    // The daemon monitors the full notification stream, then constrains
+    // visibility by the configured repo allow-list.
     const notifCall = gh.calls.find(
       (argv) => argv[0] === "api" && argv[1]?.startsWith("/notifications"),
     );
     expect(notifCall).toBeDefined();
-    expect(notifCall?.[1]).toBe("/notifications?participating=true");
+    expect(notifCall?.[1]).toBe("/notifications?all=true&per_page=100");
 
     const parsed = JSON.parse(readFileSync(ctx.inbox, "utf-8")) as {
       last_poll: string;

--- a/tests/mews/mews-daemon-runner.test.ts
+++ b/tests/mews/mews-daemon-runner.test.ts
@@ -139,6 +139,10 @@ describe("parseDaemonArgs", () => {
     expect(out.maxParallel).toBe(11);
     expect(out.searchLimit).toBe(31);
   });
+
+  it("parses --dry-run as a boolean switch", () => {
+    expect(parseDaemonArgs(["--dry-run"]).dryRun).toBe(true);
+  });
 });
 
 describe("extractBackendFlag", () => {

--- a/tests/mews/mews-daemon-scheduler.test.ts
+++ b/tests/mews/mews-daemon-scheduler.test.ts
@@ -240,10 +240,14 @@ describe("Scheduler.handleCompletion", () => {
       summary: "ok",
     });
     const record = store.loadThreadRecord("/repos/o/r/pulls/5");
+    const meta = store.readTaskMetadata("task-1");
     expect(record.failureCount).toBe(0);
     expect(record.nextRetryEpoch).toBe(0);
     expect(record.lastResult).toBe("handled");
     expect(record.lastHandledUpdatedAt).toBe("2026-04-15T12:00:00Z");
+    expect(meta.get("repo")).toBe("o/r");
+    expect(meta.get("title")).toBe("t");
+    expect(meta.get("status")).toBe("handled");
   });
 
   it("failed status bumps failure_count and schedules retry", () => {

--- a/tests/mews/mews-daemon-thread-store.test.ts
+++ b/tests/mews/mews-daemon-thread-store.test.ts
@@ -83,6 +83,33 @@ describe("ThreadStore.{write,read}TaskMetadata", () => {
     expect(list.map(([id]) => id)).toEqual(["task-a", "task-b"]);
     expect(list[1][1].get("status")).toBe("running");
   });
+
+  it("projects dashboard tasks with decoded title and summary", () => {
+    const store = new ThreadStore({ runnerHome: makeHome("dashboard") });
+    store.writeTaskMetadata("task-7", {
+      task_id: "task-7",
+      status: "simulated",
+      repo: "bingran-you/mews",
+      workspace_repo: "bingran-you/mews",
+      thread_key: "/repos/bingran-you/mews/issues/7",
+      title: "demo\\nissue",
+      kind: "mention",
+      source: "notifications",
+      updated_at: "2026-04-28T23:00:00Z",
+      started_at: "2026-04-28T23:00:01Z",
+      finished_at: "2026-04-28T23:00:02Z",
+      runner: "codex",
+      summary: "dry-run\\nscheduled task",
+    });
+    const tasks = store.listDashboardTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      task_id: "task-7",
+      status: "simulated",
+      title: "demo\nissue",
+      summary: "dry-run\nscheduled task",
+    });
+  });
 });
 
 describe("ThreadStore.cleanupOldWorkspaces", () => {


### PR DESCRIPTION
## Summary
- switch mews notification polling to the full GitHub notifications stream and filter it by the configured repo allow-list
- expose task metadata through the daemon HTTP server and render a tasks pane in the dashboard
- add a browser-backed live end-to-end harness that creates a real probe issue/comment in bingran-you/mews and verifies inbox, tasks, and dashboard rendering in dry-run mode

## Verification
- pnpm typecheck
- pnpm test
- pnpm build
- MEWS_E2E_SECONDARY_USER=Oliver-DoWhiz pnpm e2e:live