### PR TITLE
fix: launch daemon with standalone mews cli

### DIFF
--- a/src/mews/engine/commands/start.ts
+++ b/src/mews/engine/commands/start.ts
@@ -221,7 +221,8 @@ export function defaultDaemonArgs(
   argv: readonly string[],
   prefixArgs: readonly string[] = [],
 ): string[] {
-  // The ported daemon entrypoint is `mews daemon --backend=ts`.
+  // In the standalone `mews` package the daemon entrypoint is the same CLI
+  // binary invoked as `daemon --backend=ts`.
   const forwarded: string[] = [];
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
@@ -234,5 +235,5 @@ export function defaultDaemonArgs(
     if (a.startsWith("--home=") || a.startsWith("--profile=")) continue;
     forwarded.push(a);
   }
-  return [...prefixArgs, "mews", "daemon", "--backend=ts", ...forwarded];
+  return [...prefixArgs, "daemon", "--backend=ts", ...forwarded];
 }

--- a/tests/mews/mews-daemon-launchd.test.ts
+++ b/tests/mews/mews-daemon-launchd.test.ts
@@ -53,7 +53,7 @@ describe("renderLaunchdPlist", () => {
       login: "alice",
       profile: "default",
       executable: "/usr/local/bin/mews",
-      arguments: ["mews", "daemon", "--backend=ts"],
+      arguments: ["daemon", "--backend=ts"],
       logPath: "/tmp/mews.log",
       env: { PATH: "/opt/bin", HOME: "/Users/alice" },
       resolveEnvVar: noResolve,
@@ -66,7 +66,7 @@ describe("renderLaunchdPlist", () => {
     expect(xml).toContain(
       "<string>/usr/local/bin/mews</string>",
     );
-    expect(xml).toContain("<string>mews</string>");
+    expect(xml).toContain("<string>daemon</string>");
     expect(xml).toContain("<string>--backend=ts</string>");
     expect(xml).toContain("<string>/tmp/mews.log</string>");
     expect(xml).toContain("<key>PATH</key>");
@@ -94,7 +94,7 @@ describe("renderLaunchdPlist", () => {
       login: "alice",
       profile: "default",
       executable: "/usr/local/bin/mews",
-      arguments: ["mews", "daemon", "--backend=ts"],
+      arguments: ["daemon", "--backend=ts"],
       logPath: "/tmp/mews.log",
       env: {
         PATH: "/opt/bin",
@@ -147,7 +147,6 @@ describe("start command self-invocation helpers", () => {
       ]),
     ).toEqual([
       "/opt/mews/dist/cli.mjs",
-      "mews",
       "daemon",
       "--backend=ts",
       "--allow-repo",

--- a/tests/mews/mews-start.test.ts
+++ b/tests/mews/mews-start.test.ts
@@ -64,7 +64,6 @@ describe("runStart", () => {
         executable: process.execPath,
         arguments: [
           "/tmp/mews/dist/cli.mjs",
-          "mews",
           "daemon",
           "--backend=ts",
           "--allow-repo",


### PR DESCRIPTION
## Summary
- fix the background daemon argv so the standalone `mews` package launches `daemon` directly instead of passing an extra `mews` token
- update launchd and start-command regression tests to match the real executable contract
- verify the fix with build, typecheck, tests, and a real `mews start --dry-run` smoke run

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- real smoke: `node dist/cli.mjs start --allow-repo bingran-you/mews --home <tmp>/runner --profile smoke --http-port 9988 --dry-run`, then `curl http://127.0.0.1:9988/healthz`
