### PR TITLE
chore: prepare scoped npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ rest of your GitHub account.
 - GitHub CLI (`gh`) authenticated for the host you want to poll
 - Playwright Chromium only when you run the live end-to-end harness
 
+## Install From npm
+
+```bash
+npm install -g @bingran/mews
+mews --version
+```
+
 ## Install From Source
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mews",
-  "version": "0.3.0",
+  "name": "@bingran/mews",
+  "version": "0.3.1",
   "description": "A local GitHub notification daemon that scopes work to allow-listed repos and dispatches local coding agents.",
   "homepage": "https://github.com/bingran-you/mews#readme",
   "bugs": {
@@ -38,6 +38,9 @@
   "packageManager": "pnpm@10.25.0",
   "engines": {
     "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/src/mews/engine/bridge.ts
+++ b/src/mews/engine/bridge.ts
@@ -18,8 +18,8 @@ import { fileURLToPath } from "node:url";
 
 /**
  * Walk up from the current module until we find the npm package root
- * (the directory containing the package.json whose `name` is
- * `mews`).
+ * (the directory containing the package.json whose `name` matches this
+ * package).
  *
  * We can't reuse `resolveBundledPackageRoot` from the tree product
  * because that one gates on the tree SKILL.md existing, which is a
@@ -36,7 +36,7 @@ export function resolveFirstTreePackageRoot(
         const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
           name?: string;
         };
-        if (pkg.name === "mews") {
+        if (pkg.name === "mews" || pkg.name === "@bingran/mews") {
           return dir;
         }
       } catch {

--- a/src/mews/engine/daemon/http.ts
+++ b/src/mews/engine/daemon/http.ts
@@ -122,7 +122,7 @@ function resolveDashboardPath(startUrl: string = import.meta.url): string {
         const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
           name?: string;
         };
-        if (pkg.name === "mews") {
+        if (pkg.name === "mews" || pkg.name === "@bingran/mews") {
           return join(dir, "assets", "dashboard.html");
         }
       } catch {


### PR DESCRIPTION
## Summary
- rename the package to `@bingran/mews` and bump the version to `0.3.1`
- add `publishConfig.access=public` so the scoped CLI can publish cleanly to npm
- update package-root resolution so bundled assets still resolve after the scoped package rename, and document npm installation in the README

## Verification
- `pnpm verify`
- `npm pack --dry-run`
- `node dist/cli.mjs --version`
